### PR TITLE
ci(deps): use the BitGo fork of semantic-release-github-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,4 @@ jobs:
   release:
     needs:
       - test
-    uses: semantic-release-action/github-actions/.github/workflows/release.yml@v5
+    uses: BitGo/semantic-release-github-actions/.github/workflows/release.yml@v5


### PR DESCRIPTION
This replaces a third-party dependency with a fork of that dependency,
maintained by Velocity. This is part of an effort to reduce the
amount of toil involved in our maintenance process, and improve our
security posture.

Ticket: VL-2614