### PR TITLE
fix: disable semantic release git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,5 @@ jobs:
     needs:
       - test
     uses: BitGo/semantic-release-github-actions/.github/workflows/release.yml@v5
+    with:
+      disable-semantic-release-git: true


### PR DESCRIPTION
This is the option we use for other semantically released GitHub actions, for example [here](https://github.com/BitGo/gha-generate-release-notes/blob/aa529a99d75db17e7887ccdd035dd4c97bbf599b/.github/workflows/release.yml#L20).

This should fix the error seen [here](https://github.com/BitGo/install-github-release-binary/actions/runs/17458482403/attempts/1).

Ticket: VL-3425