### PR TITLE
fix: add binary directory to PATH when ignoring existing binaries

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10198,6 +10198,7 @@ async function installGitHubReleaseBinary(octokit, targetRelease, storageDirecto
   if (fs.existsSync(destinationFilename)) {
     if (ignoreExisting) {
       core2.info(`Binary already exists at ${destinationFilename}, ignoring and leaving system as-is`);
+      core2.addPath(destinationDirectory);
       return;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,8 @@ async function installGitHubReleaseBinary(
   if (fs.existsSync(destinationFilename)) {
     if (ignoreExisting) {
       core.info(`Binary already exists at ${destinationFilename}, ignoring and leaving system as-is`);
+      // Still add the directory to PATH so the binary can be found
+      core.addPath(destinationDirectory);
       return;
     }
   }


### PR DESCRIPTION
When ignore-existing-binary is true and binary exists, the action would
skip adding the directory to PATH, causing 'command not found' errors
in subsequent workflow steps.

Ticket: DO-14423
