### PR TITLE
fix: bump action runtime from node22 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     default: false
 
 runs:
-  using: node22
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## Summary
- `node22` is not a valid GitHub Actions runtime — fixes the `ArgumentOutOfRangeException` from the previous upgrade
- Bumps to `node24`, the next supported runtime after `node20`

## Test plan
- [ ] Verify the action runs successfully in a consuming workflow

Ticket: CTX-145

🤖 Generated with [Claude Code](https://claude.com/claude-code)